### PR TITLE
Update Dockerfile rust version

### DIFF
--- a/docker/Dockerfile_example_simple
+++ b/docker/Dockerfile_example_simple
@@ -1,4 +1,4 @@
-FROM rust:1.51.0 as builder
+FROM rust:1.60.0 as builder
 
 WORKDIR /rlink-rs
 


### PR DESCRIPTION
Upgrade to Rust 1.60.0. Getting `error[E0658]:arbitrary expressions in key-value attributes are unstable` with 1.51.0