### PR TITLE
Update license field following SPDX 2.1 license expression standard

### DIFF
--- a/example/example-connect/Cargo.toml
+++ b/example/example-connect/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 description = "High performance Stream Processing Framework"
 keywords = ["stream", "window", "flink", "spark"]
 repository = "https://github.com/rlink-rs/rlink-rs.git"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies.rlink]
 version = "0.6"

--- a/example/example-kafka/Cargo.toml
+++ b/example/example-kafka/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 description = "High performance Stream Processing Framework"
 keywords = ["stream", "window", "flink", "spark"]
 repository = "https://github.com/rlink-rs/rlink-rs.git"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies.rlink]
 version = "0.6"

--- a/example/example-simple/Cargo.toml
+++ b/example/example-simple/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 description = "High performance Stream Processing Framework"
 keywords = ["stream", "window", "flink", "spark"]
 repository = "https://github.com/rlink-rs/rlink-rs.git"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies.rlink]
 version = "0.6"

--- a/example/example-utils/Cargo.toml
+++ b/example/example-utils/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 description = "High performance Stream Processing Framework"
 keywords = ["stream", "window", "flink", "spark"]
 repository = "https://github.com/rlink-rs/rlink-rs.git"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [lib]
 name = "rlink_example_utils"

--- a/rlink-connectors/connector-clickhouse/Cargo.toml
+++ b/rlink-connectors/connector-clickhouse/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 description = "High performance Stream Processing Framework"
 keywords = ["stream", "window", "flink", "clickhouse"]
 repository = "https://github.com/rlink-rs/rlink-rs.git"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [lib]
 name = "rlink_connector_clickhouse"

--- a/rlink-connectors/connector-elasticsearch/Cargo.toml
+++ b/rlink-connectors/connector-elasticsearch/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 description = "High performance Stream Processing Framework"
 keywords = ["stream", "window", "flink", "elasticsearch"]
 repository = "https://github.com/rlink-rs/rlink-rs.git"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [lib]
 name = "rlink_connector_elasticsearch"

--- a/rlink-connectors/connector-kafka/Cargo.toml
+++ b/rlink-connectors/connector-kafka/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 description = "High performance Stream Processing Framework"
 keywords = ["stream", "window", "flink", "kafka"]
 repository = "https://github.com/rlink-rs/rlink-rs.git"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [lib]
 name = "rlink_connector_kafka"

--- a/rlink-deployment/rlink-kubernetes/Cargo.toml
+++ b/rlink-deployment/rlink-kubernetes/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 description = "High performance Stream Processing Framework"
 keywords = ["stream", "window", "flink", "kubernetes"]
 repository = "https://github.com/rlink-rs/rlink-rs.git"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies.rlink]
 version = "0.6"

--- a/rlink-deployment/rlink-standalone/Cargo.toml
+++ b/rlink-deployment/rlink-standalone/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 description = "High performance Stream Processing Framework"
 keywords = ["stream", "window", "flink", "spark", "standalone"]
 repository = "https://github.com/rlink-rs/rlink-rs.git"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies.rlink]
 version = "0.6"

--- a/rlink-derive/Cargo.toml
+++ b/rlink-derive/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 description = "High performance Stream Processing Framework"
 keywords = ["stream", "window", "flink"]
 repository = "https://github.com/rlink-rs/rlink-rs.git"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [lib]
 name = "rlink_derive"

--- a/rlink/Cargo.toml
+++ b/rlink/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 description = "High performance Stream Processing Framework"
 keywords = ["stream", "window", "flink"]
 repository = "https://github.com/rlink-rs/rlink-rs.git"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [lib]
 name = "rlink"


### PR DESCRIPTION
The new recommendation is to follow the SPDX 2.1 standard. This allows automatic license verification software to work properly. Reference: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields